### PR TITLE
Added an override to hear players while spectating.

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -526,11 +526,11 @@ Citizen.CreateThread(function()
 			local closestPlayer, closestPlayerDistance = GetClosestPlayer(cameraPos)
 			local closestPlayerServerId = GetPlayerServerId(closestPlayer)
 			if (closestPlayer ~= -1) and (playerSpectates[playerServerId] ~= closestPlayerServerId) then
-				print('Setting spectate override: ' .. closestPlayerServerId)
+				DebugMsg('Setting spectate override: ' .. closestPlayerServerId)
 				TriggerServerEvent('mumble-voip:setSpectate', closestPlayerServerId)
 			end
 		elseif playerSpectates[playerServerId] then
-			print('Clearing spectate override.')
+			DebugMsg('Clearing spectate override.')
 			TriggerServerEvent('mumble-voip:clearSpectate')
 		end
 	end

--- a/client.lua
+++ b/client.lua
@@ -525,7 +525,7 @@ Citizen.CreateThread(function()
 		if camDistance > 15.0 then
 			local closestPlayer, closestPlayerDistance = GetClosestPlayer(cameraPos)
 			local closestPlayerServerId = GetPlayerServerId(closestPlayer)
-			if (closestPlayer ~= -1) and (playerSpectates[playerServerId] ~= closestPlayerServerId) then
+			if (closestPlayer ~= -1) and (playerSpectates[playerServerId] ~= closestPlayerServerId) and closestPlayerDistance < 25.0 then
 				DebugMsg('Setting spectate override: ' .. closestPlayerServerId)
 				TriggerServerEvent('mumble-voip:setSpectate', closestPlayerServerId)
 			end

--- a/config.lua
+++ b/config.lua
@@ -11,6 +11,7 @@ mumbleConfig = {
     speakerRange = 1.5, -- Speaker distance in gta distance units (how close you need to be to another player to hear other players on the radio or phone)
     callSpeakerEnabled = true, -- Allow players to hear all talking participants of a phone call if standing next to someone that is on the phone
     radioSpeakerEnabled = true, -- Allow players to hear all talking participants in a radio if standing next to someone that has a radio
+	spectateAudioEnabled = true, -- Allow overriding a players location if the current gameplay camera is over a certain distance away. (Spectate mode for instance)
     radioEnabled = true, -- Enable or disable using the radio
     micClicks = true, -- Are clicks enabled or not
     micClickOn = true, -- Is click sound on active

--- a/server.lua
+++ b/server.lua
@@ -118,3 +118,17 @@ AddEventHandler("playerDropped", function()
         TriggerClientEvent("mumble:RemoveVoiceData", -1, source)
     end
 end)
+
+RegisterServerEvent('mumble-voip:setSpectate')
+AddEventHandler('mumble-voip:setSpectate', function(targetId)
+	local _source = source
+	DebugMsg('Received Spectate Override from [' .. _source .. '] to [' .. targetId .. ']')
+	TriggerClientEvent('mumble-voip:setSpectate', -1, source, targetId)
+end)
+
+RegisterServerEvent('mumble-voip:clearSpectate')
+AddEventHandler('mumble-voip:clearSpectate', function(targetId)
+	local _source = source
+	DebugMsg('Received Spectate Clear from [' .. _source .. ']')
+	TriggerClientEvent('mumble-voip:clearSpectate', -1, source)
+end)


### PR DESCRIPTION
Added a configurable option to allow speaking and hearing conversations around the camera, if the active rendering camera gets a certain distance away from the player's ped.  However, the one downside to this method is that the player will not be able to hear anything going being said near their ped.